### PR TITLE
Hook was not called - changed it in the extension.json file

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -20,7 +20,7 @@
 		"NamespaceRelationsHooks": "src/NamespaceRelationsHooks.php"
 	},
 	"Hooks": {
-		"SkinTemplateNavigationUniversal": "NamespaceRelationsHooks::onSkinTemplateNavigationUniversal"
+		"SkinTemplateNavigation::Universal": "NamespaceRelationsHooks::onSkinTemplateNavigationUniversal"
 	},
 	"config": {
 		"NamespaceRelations": {


### PR DESCRIPTION
Changed the Hook name from "SkinTemplateNavigationUniversal" to "SkinTemplateNavigation::Universal", because without that, the Hook was not called -> the extension did not work.