### PR TITLE
Move $namespaceInfo declaration to stop bug

### DIFF
--- a/src/NamespaceRelations.php
+++ b/src/NamespaceRelations.php
@@ -100,6 +100,8 @@ class NamespaceRelations {
 		 * ** string $context context
 		 */
 		$tabs = [];
+		
+		$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
 
 		if ( array_key_exists( $subjectNS, $this->namespacesToNamespace ) ) {
 			// in Main/Talk NS
@@ -114,8 +116,6 @@ class NamespaceRelations {
 				$rootText,
 				$subjectOptions
 			);
-
-			$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
 
 			// make a Talk tab
 			$talkOptions['checkExists'] = $userCanRead;


### PR DESCRIPTION
$namespaceInfo was declared in the first half of an "if" conditional, but reference in the "else" half as well - which made Mediawiki throw a fatal error.

I've moved the declaration up a few lines and it's sorted it.

Reference https://www.mediawiki.org/w/index.php?title=Topic:X90b6q18ivyaxp6p&topic_showPostId=xdw82hn9rm1anv5a#flow-post-xdw82hn9rm1anv5a